### PR TITLE
Swap plus/equal num-layer combos

### DIFF
--- a/6JP4n/modules/combos.c
+++ b/6JP4n/modules/combos.c
@@ -107,8 +107,8 @@ combo_t key_combos[] = {
     COMBO(cmb_enter_gr, KC_ENTER),
     COMBO(cmb_enter_ru, KC_ENTER),
     COMBO(cmb_minus_num, KC_MINUS),
-    COMBO(cmb_plus_num, KC_PLUS),
-    COMBO(cmb_equal_num, KC_EQUAL),
+    COMBO(cmb_plus_num, KC_EQUAL),
+    COMBO(cmb_equal_num, KC_PLUS),
     COMBO(cmb_div_num, KC_SLASH),
     COMBO(cmb_mul_num, KC_ASTR),
 


### PR DESCRIPTION
Follow-up to #22.

Swaps num-layer combo outputs:
- 456: plus -> equal
- 123: equal -> plus